### PR TITLE
Lock taglib ruby version at ~> 0.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
-script: 'bundle exec rake'
+script: "bundle exec rake"
 rvm:
-  - 2.2.5
+  - 2.7.1
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libtag1-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # CHANGELOG
 
+## 1.0.3
+
+- locked `taglib-ruby` to `~> 0.7.1` – [@asgerb](https://github.com/asgerb).
+
 ## 1.0.2
 
-* improved `SUPPORTED_FORMATS` matching that ignores case
+- improved `SUPPORTED_FORMATS` matching that ignores case
 
 ## 1.0.0
 
-* add `SUPPORTED_FORMATS` and and raise errors when not matching
-* add more thorough tests for supported formats
+- add `SUPPORTED_FORMATS` and and raise errors when not matching
+- add more thorough tests for supported formats
 
 ## 0.0.3
 
-* `AlbumArt` processor (courtesy of @asgerb)
+- `AlbumArt` processor (courtesy of @asgerb)

--- a/dragonfly_audio.gemspec
+++ b/dragonfly_audio.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dragonfly', '~> 1.0'
   spec.add_dependency 'taglib-ruby', '~> 0.7.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-minitest'

--- a/dragonfly_audio.gemspec
+++ b/dragonfly_audio.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dragonfly', '~> 1.0'
-  spec.add_dependency 'taglib-ruby'
+  spec.add_dependency 'taglib-ruby', '~> 0.7.1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.4'

--- a/lib/dragonfly_audio/version.rb
+++ b/lib/dragonfly_audio/version.rb
@@ -1,3 +1,3 @@
 module DragonflyAudio
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
We currently have no version specified for `taglib-ruby` and the gem doesn't work with the latest `1.0.0` version. I've made a #5 which adds support but thought it was nice to make a patch version update as well, which locks the `taglib-ruby` version to `0.7.1`.